### PR TITLE
Add `insecure` option to ignore ssl errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ resources:
 
 * `url`: *Required.* HTTP URL to access.
 
+* `insecure`: *Optional.* Set to `true` to ignore SSL errors.  Defaults to `false`.
+
 * `method`: *Optional.* HTTP method to use.  Defaults to GET.
 
 * `headers`: *Optional.* Map of HTTP headers to send

--- a/out
+++ b/out
@@ -20,6 +20,7 @@ cd $source
 url=$(jq -r '.source.url' < $payload)
 method=$(jq -r '.source.method // "GET"' < $payload)
 headers=$(jq -r '.source.headers // {}' < $payload)
+insecure=$(jq -r '.source.insecure // false' < $payload)
 
 data_file=$(jq -r '.params.data_file // ""' < $payload)
 data_text=$(jq -r '.params.data_text // ""' < $payload)
@@ -62,6 +63,11 @@ if [ ! -z "$data_text" ]; then
   expanded_data+=("$data_text")
 fi
 
-curl -X "$method" "${expanded_headers[@]}" "${expanded_data[@]}" "$url"
+expanded_options=()
+if [ "$insecure" = true ]; then
+  expanded_options+=("--insecure")
+fi
+
+curl -X "$method" "${expanded_headers[@]}" "${expanded_data[@]}" "${expanded_options[@]}" "$url"
 
 echo "{\"version\": {\"time\": \"$(date +%s)\"}}" >&3


### PR DESCRIPTION
Added an optional `insecure` source config option to support ignoring
SSL errors.  Values should be either `true` or `false`.  Default is
`false`.

```yaml
  source:
    url: https://my-insecure-site
    insecure: true
```

Under the hood, this adds the `--insecure` option to the `curl` command.

## Notes

* See edtan#1 for the official offering of this feature to the upstream repo.  
* Merging to this fork's `master` branch to make this feature available in [`jgriff/concourse-http-resource`](https://hub.docker.com/r/jgriff/concourse-http-resource).